### PR TITLE
"ACCESS TO INSTANCES IN INITIALIZERS" deprecation

### DIFF
--- a/app/initializers/mixpanel.js
+++ b/app/initializers/mixpanel.js
@@ -1,10 +1,7 @@
 import MixpanelMixin from '../mixin/tracking_mixin'
 
-export function initialize(container) {
-    var router = container.lookup('router:main');
-    router.on('didTransition', function() {
-      this.trackRouteChange(this.get('url'));
-    });
+export function initialize(registry, application) {
+    application.register("mixinpanel:main", MixpanelMixin);
 }
 
 export default {

--- a/app/instance-initializers/mixpanel.js
+++ b/app/instance-initializers/mixpanel.js
@@ -1,0 +1,13 @@
+import MixpanelMixin from '../mixin/tracking_mixin'
+
+export function initialize(instance) {
+    var router = instance.container.lookup('router:main');
+    router.on('didTransition', function() {
+      this.trackRouteChange(this.get('url'));
+    });
+}
+
+export default {
+  name: 'mixpanel',
+  initialize: initialize
+};


### PR DESCRIPTION
- See http://emberjs.com/deprecations/v1.x/#toc_deprecate-access-to-instances-in-initializers
- Closes remerge/ember-cli-mixpanel#5

This will now work with 2.0.0
