### PR TITLE
Register for router transitions in initializer.

### DIFF
--- a/app/instance-initializers/mixpanel.js
+++ b/app/instance-initializers/mixpanel.js
@@ -1,7 +1,7 @@
 import MixpanelMixin from '../mixin/tracking_mixin'
 
-export function initialize(container) {
-    var router = container.lookup('router:main');
+export function initialize(instance) {
+    var router = instance.container.lookup('router:main');
     router.on('didTransition', function() {
       this.trackRouteChange(this.get('url'));
     });

--- a/bower.json
+++ b/bower.json
@@ -3,15 +3,15 @@
   "dependencies": {
     "handlebars": "~1.3.0",
     "jquery": "^1.11.1",
-    "ember": "1.8.1",
-    "ember-data": "1.0.0-beta.12",
-    "ember-resolver": "~0.1.11",
-    "loader.js": "ember-cli/loader.js#1.0.1",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "rwjblue/ember-cli-test-loader#0.0.4",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.1.8",
-    "ember-qunit-notifications": "0.0.4",
-    "qunit": "~1.15.0"
+    "ember": "1.13.12",
+    "ember-data": "1.13.15",
+    "ember-resolver": "~0.1.12",
+    "loader.js": "ember-cli/loader.js#3.4.0",
+    "ember-cli-shims": "0.0.6",
+    "ember-cli-test-loader": "0.2.1",
+    "ember-load-initializers": "0.1.7",
+    "ember-qunit": "0.4.16",
+    "ember-qunit-notifications": "0.1.0",
+    "qunit": "~1.20.0"
   }
 }


### PR DESCRIPTION
Ember 1.12 onwards, there is a separation between initializers &
instance initializers. Since this module dependes on the main router
instance to be available, we have to use the instance initializers.
Also updated requirement to Ember 1.13 minimum.
